### PR TITLE
Add staff sales portal scaffold

### DIFF
--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class StaffController extends Controller
+{
+    public function dashboard()
+    {
+        return view('staff.dashboard');
+    }
+
+    public function leads()
+    {
+        return view('staff.leads');
+    }
+
+    public function notes()
+    {
+        return view('staff.notes');
+    }
+
+    public function reminders()
+    {
+        return view('staff.reminders');
+    }
+
+    public function commissions()
+    {
+        return view('staff.commissions');
+    }
+
+    public function reports()
+    {
+        return view('staff.reports');
+    }
+
+    public function conversions()
+    {
+        return view('staff.conversions');
+    }
+
+    public function payments()
+    {
+        return view('staff.payments');
+    }
+
+    public function targets()
+    {
+        return view('staff.targets');
+    }
+
+    public function referrals()
+    {
+        return view('staff.referrals');
+    }
+}

--- a/app/Http/Middleware/StaffMiddleware.php
+++ b/app/Http/Middleware/StaffMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class StaffMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!auth()->check() || !auth()->user()->is_staff()) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
             'admin'    => \App\Http\Middleware\AdminMiddleware::class,
+            'staff'    => \App\Http\Middleware\StaffMiddleware::class,
         ]);
 
         $middleware->web(append: [

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -118,6 +118,41 @@
             </x-responsive-nav-link>
 
             @endif
+
+            @if(Auth::user()->is_staff())
+
+            <x-responsive-nav-link :href="route('staff.dashboard')" :active="request()->routeIs('staff.dashboard')">
+                {{ __('Sales Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.leads')" :active="request()->routeIs('staff.leads')">
+                {{ __('Leads') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.notes')" :active="request()->routeIs('staff.notes')">
+                {{ __('Client Notes') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.reminders')" :active="request()->routeIs('staff.reminders')">
+                {{ __('Reminders') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.commissions')" :active="request()->routeIs('staff.commissions')">
+                {{ __('Commissions') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.reports')" :active="request()->routeIs('staff.reports')">
+                {{ __('Reports') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.conversions')" :active="request()->routeIs('staff.conversions')">
+                {{ __('Conversions') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.payments')" :active="request()->routeIs('staff.payments')">
+                {{ __('Payment History') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.targets')" :active="request()->routeIs('staff.targets')">
+                {{ __('Targets') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('staff.referrals')" :active="request()->routeIs('staff.referrals')">
+                {{ __('Referrals') }}
+            </x-responsive-nav-link>
+
+            @endif
         </div>
 
         <!-- Responsive Settings Options -->

--- a/resources/views/layouts/staff.blade.php
+++ b/resources/views/layouts/staff.blade.php
@@ -1,0 +1,34 @@
+                   @if(Auth::user()->is_staff())
+
+                    <x-nav-link :href="route('staff.dashboard')" :active="request()->routeIs('staff.dashboard')">
+                        {{ __('Sales Dashboard') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.leads')" :active="request()->routeIs('staff.leads')">
+                        {{ __('Leads') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.notes')" :active="request()->routeIs('staff.notes')">
+                        {{ __('Client Notes') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.reminders')" :active="request()->routeIs('staff.reminders')">
+                        {{ __('Reminders') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.commissions')" :active="request()->routeIs('staff.commissions')">
+                        {{ __('Commissions') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.reports')" :active="request()->routeIs('staff.reports')">
+                        {{ __('Reports') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.conversions')" :active="request()->routeIs('staff.conversions')">
+                        {{ __('Conversions') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.payments')" :active="request()->routeIs('staff.payments')">
+                        {{ __('Payment History') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.targets')" :active="request()->routeIs('staff.targets')">
+                        {{ __('Targets') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('staff.referrals')" :active="request()->routeIs('staff.referrals')">
+                        {{ __('Referrals') }}
+                    </x-nav-link>
+                    @endif
+

--- a/resources/views/staff/commissions.blade.php
+++ b/resources/views/staff/commissions.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Commission Tracker') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Track commissions for bookings and payments.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/conversions.blade.php
+++ b/resources/views/staff/conversions.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Client Conversion Tracker') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Monitor client status from new to paid.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/dashboard.blade.php
+++ b/resources/views/staff/dashboard.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Sales Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Overview of leads, commissions, and performance.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/leads.blade.php
+++ b/resources/views/staff/leads.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Lead Management') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Manage and assign leads.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/notes.blade.php
+++ b/resources/views/staff/notes.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Client Notes & Follow-Ups') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Record notes and follow-up actions for clients.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/payments.blade.php
+++ b/resources/views/staff/payments.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Commission Payment History') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>History of commission payouts.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/referrals.blade.php
+++ b/resources/views/staff/referrals.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Referral Links') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Generate and track referral links.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/reminders.blade.php
+++ b/resources/views/staff/reminders.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Lead Reminders') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Automatic reminders and alerts for leads.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/reports.blade.php
+++ b/resources/views/staff/reports.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Sales Reports') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Weekly and monthly performance reports.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/staff/targets.blade.php
+++ b/resources/views/staff/targets.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Target vs Achievement') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Compare targets against achievements.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ClientController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\StaffController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -33,6 +34,19 @@ Route::middleware('auth')->group(function () {
         Route::get('/communications', [AdminController::class, 'communications'])->name('communications');
         Route::get('/logs', [AdminController::class, 'logs'])->name('logs');
         Route::get('/notes', [AdminController::class, 'notes'])->name('notes');
+    });
+
+    Route::middleware('staff')->prefix('staff')->name('staff.')->group(function () {
+        Route::get('/dashboard', [StaffController::class, 'dashboard'])->name('dashboard');
+        Route::get('/leads', [StaffController::class, 'leads'])->name('leads');
+        Route::get('/notes', [StaffController::class, 'notes'])->name('notes');
+        Route::get('/reminders', [StaffController::class, 'reminders'])->name('reminders');
+        Route::get('/commissions', [StaffController::class, 'commissions'])->name('commissions');
+        Route::get('/reports', [StaffController::class, 'reports'])->name('reports');
+        Route::get('/conversions', [StaffController::class, 'conversions'])->name('conversions');
+        Route::get('/payments', [StaffController::class, 'payments'])->name('payments');
+        Route::get('/targets', [StaffController::class, 'targets'])->name('targets');
+        Route::get('/referrals', [StaffController::class, 'referrals'])->name('referrals');
     });
 });
 


### PR DESCRIPTION
## Summary
- add StaffController and middleware to authorize staff users
- scaffold sales portal routes and views for leads, commissions, reports, and more
- expose staff navigation links and middleware alias

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b27303371c8324b84dfa137e49adcc